### PR TITLE
Fix type hint import issues and circular imports

### DIFF
--- a/models/model_config.py
+++ b/models/model_config.py
@@ -4,7 +4,7 @@ Model configuration and management for Phi-3 integration
 import os
 import psutil
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 import logging
 
 from config import MODEL_CONFIG, SYSTEM_CONFIG
@@ -170,4 +170,3 @@ class ModelConfig:
         ])
         
         return tips
-

--- a/simple_launch.py
+++ b/simple_launch.py
@@ -1,0 +1,41 @@
+"""
+Simple launcher that bypasses import issues
+"""
+import os
+import sys
+import subprocess
+
+def main():
+    """Launch Streamlit with minimal dependencies"""
+    try:
+        # Get current directory
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        
+        # Path to streamlit app
+        app_path = os.path.join(current_dir, "ui", "streamlit_app.py")
+        
+        print("🚀 Starting Agentic AI Forecasting System...")
+        print("📊 Opening at: http://localhost:8501")
+        print("⏹️  Press Ctrl+C to stop")
+        print("-" * 50)
+        
+        # Set environment variable to help with imports
+        env = os.environ.copy()
+        env['PYTHONPATH'] = current_dir
+        
+        # Launch streamlit
+        cmd = [sys.executable, "-m", "streamlit", "run", app_path, 
+               "--server.address", "localhost", "--server.port", "8501"]
+        
+        subprocess.run(cmd, env=env)
+        
+    except KeyboardInterrupt:
+        print("\n🛑 Stopped by user")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        print("\n💡 Try installing dependencies:")
+        print("   pip install -r requirements.txt")
+
+if __name__ == "__main__":
+    main()
+

--- a/test_streamlit.py
+++ b/test_streamlit.py
@@ -1,0 +1,76 @@
+"""
+Minimal Streamlit app to test if basic functionality works
+"""
+import streamlit as st
+import pandas as pd
+import numpy as np
+import sys
+import os
+
+# Add project root to path
+project_root = os.path.dirname(os.path.abspath(__file__))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+def main():
+    """Main Streamlit app"""
+    st.set_page_config(
+        page_title="Agentic AI Forecasting System - Test",
+        page_icon="🤖",
+        layout="wide"
+    )
+    
+    st.title("🤖 Agentic AI Forecasting System - Test Mode")
+    st.write("This is a minimal test to verify Streamlit works correctly.")
+    
+    # Test basic functionality
+    st.header("📊 Basic Test")
+    
+    # Create sample data
+    dates = pd.date_range('2023-01-01', periods=12, freq='M')
+    sample_data = pd.DataFrame({
+        'Date': dates,
+        'ACD Call Volume Actuals': np.random.randint(100, 200, 12),
+        'Driver_Forecast': np.random.randint(90, 210, 12)
+    })
+    
+    st.subheader("Sample Data")
+    st.dataframe(sample_data)
+    
+    # Test chart
+    st.subheader("Sample Chart")
+    st.line_chart(sample_data.set_index('Date'))
+    
+    # Test imports
+    st.header("🧪 Import Test")
+    
+    try:
+        # Test basic imports
+        from config import MODEL_CONFIG
+        st.success("✅ Config import successful")
+        
+        from data.data_processor import DataProcessor
+        st.success("✅ Data processor import successful")
+        
+        from utils.forecasting_utils import ForecastingUtils
+        st.success("✅ Forecasting utils import successful")
+        
+        st.success("🎉 All basic imports working!")
+        
+    except Exception as e:
+        st.error(f"❌ Import error: {str(e)}")
+        st.info("💡 This helps identify which specific import is causing issues")
+    
+    st.header("📋 Next Steps")
+    st.info("""
+    If this test page loads successfully, the basic Streamlit setup is working.
+    
+    To run the full application:
+    1. Make sure all dependencies are installed: `pip install -r requirements.txt`
+    2. Download the Phi-3 model file
+    3. Run: `python simple_launch.py`
+    """)
+
+if __name__ == "__main__":
+    main()
+

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -7,7 +7,17 @@ This module contains:
 - Visualization utilities
 """
 
-from .streamlit_app import main
+# Import components only, not the main streamlit app to avoid circular imports
+from .components.data_upload import DataUploadComponent
+from .components.forecast_display import ForecastDisplayComponent
+from .components.tweaking_interface import TweakingInterfaceComponent
+from .components.explanation_interface import ExplanationInterfaceComponent
+from .utils.chart_generator import ChartGenerator
 
-__all__ = ['main']
-
+__all__ = [
+    'DataUploadComponent',
+    'ForecastDisplayComponent', 
+    'TweakingInterfaceComponent',
+    'ExplanationInterfaceComponent',
+    'ChartGenerator'
+]


### PR DESCRIPTION
- Added missing List import in models/model_config.py
- Fixed circular import in ui/__init__.py by removing streamlit_app import
- Created simple_launch.py with PYTHONPATH environment variable
- Added test_streamlit.py for minimal functionality testing
- These fixes resolve the NameError: name 'List' is not defined

Users can now run:
- python simple_launch.py (recommended)
- streamlit run test_streamlit.py (for testing)